### PR TITLE
Ensure compatible scipy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
         "pillow==7.2.0",
         "scikit-learn==0.23.1",
         "compose==1.1.1",
-        "matplotlib==3.2.2"
+        "matplotlib==3.2.2",
+        "scipy==1.4.1"
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
In order for face-mask-detector to run correctly, all libraries implemented within the program should install without issue.
While executing the following command: ```pip install -e '.[dev]'```, the following error occurred: 

```ERROR: tensorflow 2.2.0 has requirement scipy==1.4.1; python_version >= "3", but you'll have scipy 1.5.2 which is incompatible.```

To resolve this, I added ```"scipy==1.4.1"``` to the required installations within setup.py.